### PR TITLE
BugFix/AKDS-79/fix-popup-text-scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -839,6 +839,7 @@ body,
 @keyframes fade-in {
   0% {
     opacity: 0;
+    visibility: visible;
   }
 
   100% {
@@ -872,6 +873,7 @@ body,
   }
 
   100% {
+    visibility: hidden;
     opacity: 0;
   }
 }


### PR DESCRIPTION
The problem here was the the `splash_screen_background` was till a page element even though the opacity was 0. 
It was covering the scroll bars.
It seems like this opacity issue does not affect everything, like the hover... but it does affect scroll.
My solution was to just set the element that we `fade-out` to `visibility: hidden` then on `fade-in` make it visible again.