### PR TITLE
Improvement/AKDS-30/AKDS-58/AKDS-63/mobile--orbit-width-params-and-line-animations-orbit-labels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1003,68 +1003,6 @@ body,
 
   }
 
-  ._dotted img,
-  ._fill img {
-    width: 100%;
-    height: auto;
-    object-fit: contain;
-  }
-
-  ._fill img {
-    position: absolute;
-    z-index: -2;
-  }
-
-  .heo_solid {
-    top: 36%;
-    left: 59%;
-  }
-
-  ._label img {
-    height: 25px;
-    position: absolute;
-    z-index: 2
-  }
-
-  .leo_label {
-    left: 67px;
-    top: 85px;
-
-  }
-
-  .meo_label {
-    left: 42px;
-    top: 85px;
-  }
-
-  .heo_label {
-    left: 211px;
-    top: 67px;
-
-  }
-
-  .gso_label {
-    left: 20px;
-    top: 50px;
-  }
-
-  .geo_label {
-    left: 46px;
-    top: 156px;
-  }
-
-  .gto_label {
-    left: 288px;
-    top: 154px;
-  }
-
-  .gto img,
-  .geo img,
-  .heo img {
-    transform: translate(-49.9%, -49.9%);
-  }
-
-
   .earth {
     transform: translate(-50%, -50%);
     z-index: -1;
@@ -1159,9 +1097,39 @@ body,
 
   }
 
+  ._label img {
+    height: 25px;
+    position: absolute;
+    z-index: 2
+  }
+
+  ._dotted img,
+  ._fill img {
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+  }
+
+  ._fill img {
+    position: absolute;
+    z-index: -2;
+  }
+
+  .gto img,
+  .geo img,
+  .heo img {
+    transform: translate(-49.9%, -49.9%);
+  }
+
+
   .leo_line_container {
     top: 454px;
     left: -167px
+  }
+
+  .leo_label {
+    left: 67px;
+    top: 85px;
   }
 
   .meo_line_container {
@@ -1169,30 +1137,59 @@ body,
     left: -197px;
   }
 
+  .meo_label {
+    left: 42px;
+    top: 85px;
+  }
 
   .heo_line_container {
     top: 224px;
-    left: 160px;
+    left: 170px;
+  }
+
+  .heo_label {
+    left: 211px;
+    top: 67px;
+  }
+
+  .heo_solid {
+    top: 36%;
+    left: 59%;
   }
 
   .gso_line_container {
-    top: 450px;
-    left: 108px;
+    top: 521px;
+    left: 91px;
   }
 
-
+  .gso_label {
+    left: 20px;
+    top: 50px;
+  }
 
   .geo_line_container {
-    top: 429px;
+    top: 438px;
     left: 83px;
   }
 
+  .geo_label {
+    left: 46px;
+    top: 156px;
+  }
+
+  .geo_fill {
+    top: 51%;
+  }
+
   .gto_line_container {
-    top: 431px;
+    top: 436px;
     left: 67px;
   }
 
-
+  .gto_label {
+    left: 288px;
+    top: 154px;
+  }
 
 
 
@@ -1307,76 +1304,190 @@ body,
 }
 
 
-@media (max-width: 450px) {
+@media (max-width: 400px) {
   :root {
-    --mobile-orbit-size: 297px;
+    --mobile-orbit-size: 330px;
   }
 
   .leo_line_container {
-    top: 446px;
+    top: 452px;
+  }
+
+  .leo_label {
+    left: 67px;
+    top: 85px;
   }
 
   .meo_line_container {
-    left: -187px;
+    left: -167px;
+    top: 499px;
   }
 
+  .meo_label {
+    left: 42px;
+    top: 85px;
+  }
 
   .heo_line_container {
-    left: 77px;
+    left: 113px;
     top: 262px;
   }
 
-  .gso_line_container {
-    top: 432px;
-    left: 74px;
-    width: 400px !important;
+  .heo_label {
+    left: 211px;
+    top: 67px;
 
+  }
+
+  .gso_line_container {
+    top: 467px;
+    left: 79px;
+  }
+
+  .gso_label {
+    left: 20px;
+    top: 50px;
   }
 
   .geo_line_container {
-    top: 406px;
+    top: 426px;
     left: 19px
   }
 
-  .geo_fill {
-    top: 51%;
+  .geo_label {
+    left: 46px;
+    top: 156px;
   }
 
   .gto_line_container {
-    top: 406px;
-    left: 5px;
+    top: 421px;
+    left: 22px;
   }
 
+  .gto_label {
+    left: 306px;
+    top: 148px;
+  }
 }
 
-@media (max-width: 350px) {
+@media (max-width: 360px) {
   :root {
-    --mobile-orbit-size: 260px;
+    --mobile-orbit-size: 306px;
   }
 
   .leo_line_container {
-    top: 435px;
+    top: 448px;
+  }
+
+  .leo_label {
+    left: 67px;
+    top: 85px;
   }
 
   .meo_line_container {
     left: -166px;
+    top: 490px;
+  }
+
+  .meo_label {
+    left: 42px;
+    top: 85px;
   }
 
 
   .heo_line_container {
-    left: 35px;
-    top: 262px;
+    left: 100px;
+    top: 242px;
+  }
+
+  .heo_label {
+    left: 197px;
+    top: 46px;
   }
 
   .gso_line_container {
-    top: 410px;
+    top: 484px;
     left: 37px;
+  }
 
+  .gso_label {
+    left: 20px;
+    top: 50px;
   }
 
   .geo_line_container {
-    top: 406px;
+    top: 412px;
     left: 19px
+  }
+
+  .geo_label {
+    left: 46px;
+    top: 156px;
+  }
+
+  .gto_line_container {
+    top: 410px;
+    left: 5px;
+  }
+
+  .gto_label {
+    left: 306px;
+    top: 148px;
+  }
+}
+
+@media (max-width: 320px) {
+  :root {
+    --mobile-orbit-size: 272px;
+  }
+
+  .leo_line_container {
+    top: 438px;
+  }
+
+  .leo_label {
+    left: 67px;
+    top: 85px;
+  }
+
+  .meo_line_container {
+    left: -166px;
+    top: 472px;
+  }
+
+  .meo_label {
+    left: 42px;
+    top: 43px;
+  }
+
+  .heo_line_container {
+    left: 64px;
+    top: 239px;
+  }
+
+  .heo_label {
+    left: 179px;
+    top: 41px;
+  }
+
+  .gso_line_container {
+    top: 467px;
+    left: -2px;
+  }
+
+  .gso_label {
+    left: 20px;
+    top: 50px;
+  }
+
+  .geo_line_container {
+    top: 394px;
+    left: -13px;
+  }
+
+  .geo_label {
+    left: 38px;
+    top: 118px;
   }
 
   .geo_fill {
@@ -1384,7 +1495,21 @@ body,
   }
 
   .gto_line_container {
-    top: 406px;
-    left: 5px;
+    top: 390px;
+    left: -2px;
+  }
+
+  .gto_label {
+    left: 218px;
+    top: 117px;
+  }
+}
+
+@media (max-height: 640px) {
+
+  /* Shrink popup container for shorter height devices */
+  .orbit_title_popup_container {
+    height: 45%;
+    top: 55%;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -692,7 +692,7 @@ body,
   -webkit-font-smoothing: antialiased;
   font-size: 33px;
   letter-spacing: 1.33px;
-  padding-bottom: 24px;;
+  padding-bottom: 24px;
   padding-left: 3%;
   padding-right: 5%;
   color: #363135;
@@ -915,9 +915,10 @@ body,
 /*****************************************************************************************************************************************************/
 
 
+
 @media (max-width: 500px) {
   :root {
-    --mobile-orbit-size: 350px;
+    --mobile-orbit-size: 360px;
     --mobile-view-width: 90vw;
   }
 
@@ -1099,6 +1100,9 @@ body,
     flex: 5;
     display: flex;
     justify-content: center;
+    /* background image will hide the connecting line underneath the popup container at smaller heights */
+    background-image: url('./assets/background.png');
+
   }
 
   .orbit_title_popup {
@@ -1299,5 +1303,88 @@ body,
     top: -26%;
     user-select: none;
     z-index: 0 !important;
+  }
+}
+
+
+@media (max-width: 450px) {
+  :root {
+    --mobile-orbit-size: 297px;
+  }
+
+  .leo_line_container {
+    top: 446px;
+  }
+
+  .meo_line_container {
+    left: -187px;
+  }
+
+
+  .heo_line_container {
+    left: 77px;
+    top: 262px;
+  }
+
+  .gso_line_container {
+    top: 432px;
+    left: 74px;
+    width: 400px !important;
+
+  }
+
+  .geo_line_container {
+    top: 406px;
+    left: 19px
+  }
+
+  .geo_fill {
+    top: 51%;
+  }
+
+  .gto_line_container {
+    top: 406px;
+    left: 5px;
+  }
+
+}
+
+@media (max-width: 350px) {
+  :root {
+    --mobile-orbit-size: 260px;
+  }
+
+  .leo_line_container {
+    top: 435px;
+  }
+
+  .meo_line_container {
+    left: -166px;
+  }
+
+
+  .heo_line_container {
+    left: 35px;
+    top: 262px;
+  }
+
+  .gso_line_container {
+    top: 410px;
+    left: 37px;
+
+  }
+
+  .geo_line_container {
+    top: 406px;
+    left: 19px
+  }
+
+  .geo_fill {
+    top: 51%;
+  }
+
+  .gto_line_container {
+    top: 406px;
+    left: 5px;
   }
 }


### PR DESCRIPTION
Closes AKDS-30
Closes AKDS-58

I added breakpoints at 500 , 400, 360, 320 to ensure connecting_line accuracy.
Note: Because I rotated the connection line apparatus (lol) 270deg so the line would animate up instead of right, it unfortunately, it ties the 'width' of the container to the height of the line. Which is why I need multiple breakpoints to adjust for that.

I added height breakpoint at 640 to make the popup_info_container shorter for small height devices