### PR TITLE
BugFix/AKDS-78/uneccesary-scroll-bars

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -635,7 +635,7 @@ body,
   height: 87%;
   display: flex;
   flex-direction: column;
-  overflow: scroll;
+  overflow: auto;
   margin-left: 7%;
   margin-top: 5%;
 }


### PR DESCRIPTION
`overflow: scroll;`  implies we always want the scroll bars there whereas  
`overflow: auto;` means put them there when we need them
![explorer_pGZIRhgx4Q](https://github.com/rraaschfilament/across-karman/assets/85306386/da5aeccd-b2ae-44cf-af00-fbabf04c03e8)
