### PR TITLE
BugFix/AKDS-73/deselect-orbits

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,8 @@ body,
   margin: 0px;
   display: flex;
   overflow: hidden;
+  --reset_selection_left: 150px;
+
 }
 
 .background_container {
@@ -108,6 +110,37 @@ body,
   width: 85%;
   height: 100%;
   z-index: 1;
+}
+
+.reset_orbit_selection_container {
+  position: absolute;
+  opacity: 30%;
+  left: var(--reset_selection_left);
+  overflow: clip;
+  height: 100vh;
+  width: 95vw;
+  align-self: flex-end;
+  display: flex;
+  z-index: 2;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.reset_selection {
+  opacity: 30%;
+  align-self: flex-end;
+  z-index: 2;
+}
+
+.reset_selection.top {
+  height: 49vh;
+  width: 100%;
+}
+
+.reset_selection.bottom {
+  height: 51vh;
+  width: calc(56vw + var(--reset_selection_left));
+
 }
 
 .player {
@@ -1022,6 +1055,38 @@ body,
     width: 100%;
     height: 37px;
     object-fit: contain;
+  }
+
+  .reset_orbit_selection_container {
+    /* outline: 2px dotted dodgerblue; */
+    position: absolute;
+    opacity: 30%;
+    left: unset;
+    top: 90px;
+    overflow: clip;
+    height: calc(47% - 90px);
+    width: 100vw;
+    align-self: flex-end;
+    display: flex;
+    z-index: 2;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .reset_selection {
+    opacity: 30%;
+    align-self: flex-end;
+    z-index: 2;
+  }
+
+  .reset_selection.top {
+    /* background-color: tomato; */
+    height: 100%;
+    width: 100%;
+  }
+
+  .reset_selection.bottom {
+    display: none;
   }
 
   .splash_screen_background {

--- a/src/App.css
+++ b/src/App.css
@@ -114,7 +114,6 @@ body,
 
 .reset_orbit_selection_container {
   position: absolute;
-  opacity: 30%;
   left: var(--reset_selection_left);
   overflow: clip;
   height: 100vh;

--- a/src/App.css
+++ b/src/App.css
@@ -132,6 +132,7 @@ body,
 }
 
 .reset_selection.top {
+  /* background-color: red; */
   height: 49vh;
   width: 100%;
 }
@@ -139,6 +140,7 @@ body,
 .reset_selection.bottom {
   height: 51vh;
   width: calc(56vw + var(--reset_selection_left));
+  /* background-color: green; */
 
 }
 
@@ -676,7 +678,7 @@ body,
   animation-name: fly-in-right;
   animation-duration: 1s;
   animation-fill-mode: forwards;
-  z-index: 1;
+  z-index: 2;
 }
 
 

--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@ body,
   margin: 0px;
   display: flex;
   overflow: hidden;
-  --reset_selection_left: 150px;
+  --reset_selection_left: 228px;
 
 }
 
@@ -113,6 +113,7 @@ body,
 }
 
 .reset_orbit_selection_container {
+  /* outline: 3px dotted dodgerblue; */
   position: absolute;
   left: var(--reset_selection_left);
   overflow: clip;
@@ -138,9 +139,9 @@ body,
 }
 
 .reset_selection.bottom {
+  /* background-color: green; */
   height: 51vh;
   width: calc(56vw + var(--reset_selection_left));
-  /* background-color: green; */
 
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,7 +190,18 @@ export const App: React.FC = () => {
           <SplashScreen setSplashScreen={handleSetSplashScreen} />
         </div>
       )}
-
+      {!isSplashScreen && (
+        <div className="reset_orbit_selection_container">
+          <div
+            className="reset_selection top"
+            onClick={resetOrbitSelection}
+          ></div>
+          <div
+            className="reset_selection bottom"
+            onClick={resetOrbitSelection}
+          ></div>
+        </div>
+      )}
       {showNavBar && (
         <div className="nav_container">
           {!flyToId && (
@@ -225,7 +236,6 @@ export const App: React.FC = () => {
         id="earth_orbits_container"
         className={"earth_orbits_container"}
         onTransitionEnd={handleflyTransitionEnd}
-        onClick={resetOrbitSelection}
       >
         {!activeId && !hoveringId && (
           <Player
@@ -286,7 +296,6 @@ export const App: React.FC = () => {
               return <SingleOrbitImage id={id} imageDesc="_dotted" />;
             })}
       </div>
-
       {flyToId && flyTransitionEnded && (
         <img
           src={orbitBackground}
@@ -310,7 +319,6 @@ export const App: React.FC = () => {
           desc="_orbit_details"
         />
       )}
-
       {currentStaticImg && (
         <TestStaticImgCloseup id={flyToId} imageNum={currentStaticImg} />
       )}


### PR DESCRIPTION

For Browser I needed two trigger boxes to adjust for where the popup container renders/

The colors are just to show where the position of the container and the masking divs are. They (should be) turned off now.

![deselecting-orbits](https://github.com/rraaschfilament/across-karman/assets/85306386/e7c56650-f614-41d4-b939-1442df9c9f7e)

![I50kxdak4G](https://github.com/rraaschfilament/across-karman/assets/85306386/51ecf698-5d90-43d3-a058-2f349ed0e54a)
