### PR TITLE
Bug fix/NONE/fix use mobile device

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1487,13 +1487,21 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     padding-bottom: 0%;
   }
 
+  .orbit_closeup_section_headings {
+    padding-bottom: 5px;
+  }
+
+  .orbit_closeup_section_headings:not(:nth-child(3)) {
+    padding-top: 20px;
+  }
+
   .orbit_closeup_subheader {
     font-size: 25px;
     letter-spacing: 1.33px;
     padding-top: 1%;
     padding-left: 3%;
     padding-right: 5%;
-    padding-bottom: 2%;
+    padding-bottom: 25px;
   }
 
   .orbit_closeup_body {
@@ -1502,7 +1510,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     line-height: 2;
     padding-left: 3%;
     padding-right: 5%;
-    padding-bottom: 5%;
+    padding-bottom: 0;
   }
 
   .static_satellite_image_container {

--- a/src/App.css
+++ b/src/App.css
@@ -557,6 +557,7 @@ body,
   position: relative;
   padding-left: 7%;
   padding-top: 3%;
+  margin-bottom: 8px;
   justify-content: left;
   flex: 0.3;
 }
@@ -574,6 +575,15 @@ body,
   font-weight: 300;
   flex: 3;
   overflow: auto;
+}
+
+.orbit_title_info_section {
+  margin-bottom: 16px;
+  font-weight: bold;
+}
+
+.orbit_title_info_section span {
+  font-weight: normal;
 }
 
 .orbit_title_info_footer {

--- a/src/App.css
+++ b/src/App.css
@@ -717,6 +717,8 @@ body,
   padding-bottom: 30px;
 }
 
+
+
 .orbit_closeup_subheader {
   font-family: "alternate-gothic-no-1-d", sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -743,6 +745,10 @@ body,
   position: relative;
   text-align: left;
   opacity: 1;
+}
+
+.orbit_closeup_section_headings:not(:nth-child(3)) {
+  margin-top: 16px;
 }
 
 .orbit_closeup_body {

--- a/src/App.css
+++ b/src/App.css
@@ -926,6 +926,8 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 }
 
 /* Samsung Galaxy Tab S8 - Landscape */
+/* IPad Air 5 Landscape */
+/* IPad Mini Landscape */
 @media only screen and (max-device-width : 1235px) and (orientation : landscape) {
 
   .hard_scale_value {
@@ -1012,11 +1014,8 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .gto_line_container {
-    left: 56%;
+    left: 50%;
   }
-
-
-
 
 
   .static_satellite_image_container {
@@ -1032,11 +1031,18 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     scale: 0.5;
   }
 
-}
+  .orbit_closeup_button_plain,
+  .orbit_closeup_button_outlined {
+    font-size: 24px;
+    padding: 12px 32px;
+    height: fit-content;
+  }
 
+}
 
 /* IPad Air 5 Landscape */
 /* IPad Mini Landscape */
+/* Fine tunes a few things for these devices */
 @media only screen and (max-device-width : 1110px) and (orientation : landscape) {
 
   .orbit_nav_button {
@@ -1056,13 +1062,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     left: 43%;
   }
 
-  .orbit_closeup_button_plain,
-  .orbit_closeup_button_outlined {
-    font-size: 24px;
-    padding: 12px 32px;
-    height: fit-content;
-  }
-
   .leo_orbit_details,
   .meo_orbit_details,
   .heo_orbit_details,
@@ -1070,30 +1069,14 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   .geo_orbit_details {
     width: 100%
   }
-}
-
-/* iPad Mini - Landscape */
-/* Samsung Galaxy Tab S8 - Landscape */
-/* @media (max-width: 1040px) {
-
-  .geo_label {
-    left: 131px;
-    top: 398px;
-  }
-
-  .orbit_closeup_button_plain,
-  .orbit_closeup_button_outlined {
-    font-size: 24px;
-    padding: 12px 32px;
-    height: fit-content;
-  }
-
-} */
+} 
 
 /* iPad Air - Portrait */
+/* iPad Mini - Portrait */
 /* Samsung Galaxy Tab S8 - Portrait */
 /* Desktop  */
-@media (max-width: 1180px) {
+@media (max-width: 1080px),
+(max-width: 1132px) {
   :root {
     --mobile-orbit-size: 600px;
     --mobile-view-width: 90vw;

--- a/src/App.css
+++ b/src/App.css
@@ -964,6 +964,18 @@ body,
   .earth_orbits_container {
     top: -10vh;
   }
+
+  .orbit_closeup_text {
+    height: 80vh;
+  }
+
+  .orbit_closeup_button_plain,
+  .orbit_closeup_button_outlined {
+    font-size: 24px;
+    padding: 12px 32px;
+    height: fit-content;
+  }
+
 }
 
 

--- a/src/App.css
+++ b/src/App.css
@@ -28,8 +28,7 @@ body,
   position: absolute;
   width: 100%;
   height: 100%;
-  background: linear-gradient(113deg, #0024394d 0%, #3631354d 100%) 0% 0%
-    no-repeat padding-box;
+  background: linear-gradient(113deg, #0024394d 0%, #3631354d 100%) 0% 0% no-repeat padding-box;
   opacity: 1;
   z-index: 1;
 }
@@ -908,7 +907,9 @@ body,
   }
 }
 
-@media (max-width: 1170px) {
+/* iPad Air - Landscape */
+/* Acceptable */
+@media (max-width: 1180px) {
   :root {
     --min-orbit-size: 900px;
   }
@@ -923,13 +924,13 @@ body,
   }
 
   .earth {
-    height: 48%;
+    height: 51%;
   }
 
   .earth_orbits_container {
     position: relative;
     left: 30vw;
-    bottom: 5vh;
+    bottom: 7vh;
     min-height: var(--min-orbit-size);
     max-height: var(--min-orbit-size);
     min-width: var(--min-orbit-size);
@@ -957,36 +958,15 @@ body,
   }
 }
 
-@media (max-width: 1000px) {
+/* iPad Mini - Landscape */
+/* Samsung Galaxy Tab S8 - Landscape */
+@media (max-width: 1040px) {
   .earth_orbits_container {
-    left: 27vw;
+    top: -10vh;
   }
 }
 
-@media (max-width: 750px) {
-  .splash_screen_body {
-    width: 90%;
-  }
 
-  .orbit_closeup_text {
-    margin-left: 12%;
-  }
-
-  .orbit_closeup_button_outlined {
-    font-size: 30px;
-  }
-
-  .orbit_closeup_button_plain {
-    font-size: 30px;
-  }
-
-  .earth_orbits_container {
-    left: 18vw;
-  }
-}
-
-/*****************************************************************************************************************************************************/
-/*****************************************************************************************************************************************************/
 /*****************************************************************************************************************************************************/
 
 /* 
@@ -999,15 +979,31 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   display: none !important;
 }
 
-@media (max-width: 500px) {
+.orbit_closeup_back_button_mobile {
+  visibility: hidden;
+}
+
+/* iPad Air - Portrait */
+@media (max-width: 1000px) {
   :root {
-    --mobile-orbit-size: 360px;
+    --mobile-orbit-size: 600px;
     --mobile-view-width: 90vw;
     --mobile-view-splash-body-width: 60vw;
+    --orbit-name-top-offset: -2px;
+    --mobile-orbit-top-offset: 130px;
+    --orbit-name-top-special-offset: calc(var(--orbit-name-top-offset) + 8px);
+
   }
 
   .hard_scale_value {
-    transform: scale(1) !important;
+    transform: unset !important;
+  }
+
+  .orbit_closeup_back_button_mobile {
+    visibility: visible;
+    position: relative;
+    top: -35.5vh;
+    left: 86vw;
   }
 
   .background_container {
@@ -1028,13 +1024,13 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     justify-content: space-between;
     height: 70px;
     position: static;
-    margin-top: 20px;
+    margin-top: 50px;
   }
 
   /* Horizontal alignment for mobile view */
   .orbit_title_container {
     position: static;
-    width: var(--mobile-view-width);
+    width: 100%;
     display: inline-flex;
     flex-direction: row;
     justify-content: space-between;
@@ -1061,34 +1057,33 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .orbit_name.meo {
-    top: 0px;
-    left: 8px;
+    top: var(--orbit-name-top-offset);
+    left: 15px;
   }
 
   .orbit_name.leo {
-    top: 0px;
-    left: 8px;
+    top: var(--orbit-name-top-offset);
+    left: 15px;
   }
 
   .orbit_name.gso {
-    top: 0px;
-    left: -89px;
+    top: var(--orbit-name-top-offset);
+    left: -55px;
   }
 
   .orbit_name.heo {
-    top: 8px;
-    left: 71px;
+    top: var(--orbit-name-top-special-offset);
+    left: 77px;
   }
 
   .orbit_name.geo {
-    user-select: none;
-    top: 8px;
-    left: -17px;
+    top: var(--orbit-name-top-special-offset);
+    left: 15px;
   }
 
   .orbit_name.gto {
-    top: 8px;
-    left: -51px;
+    top: var(--orbit-name-top-special-offset);
+    left: -20px;
   }
 
   .visible {
@@ -1100,12 +1095,11 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .orbit_nav_button_image {
-    /* outline: 2px dotted yellow; */
     position: relative;
     object-fit: contain;
     object-position: left;
     width: 100%;
-    height: 40px;
+    height: 60px;
   }
 
   .reset_selection {
@@ -1115,9 +1109,10 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .reset_selection.top {
+    /* background-color: pink; */
     left: 0;
-    top: 90px;
-    height: calc(46% - 90px);
+    top: var(--mobile-orbit-top-offset);
+    height: calc(46% - var(--mobile-orbit-top-offset));
     width: 100vw;
   }
 
@@ -1185,7 +1180,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   .earth_orbits_container {
     position: fixed;
     aspect-ratio: 1;
-    top: 90px;
+    top: var(--mobile-orbit-top-offset);
     /* can't use tranform here for iPhone 11 Safari */
     /* calculate left so that the container is centered in the window*/
     left: calc(50vw - (var(--mobile-orbit-size) / 2));
@@ -1247,7 +1242,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     overflow: unset;
     height: fit-content;
     width: 90%;
-    font-size: 32px;
+    font-size: 40px;
   }
 
   .orbit_title_info_footer {
@@ -1255,13 +1250,14 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .orbit_title_info_body {
-    font-size: 12px;
+    font-size: 16px;
     width: 85%;
     flex: 1;
   }
 
   .risk_icon {
     margin-right: 12px;
+    height: 40px;
   }
 
   .drawing {
@@ -1287,7 +1283,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   ._label img {
-    height: 25px;
+    height: 35px;
     position: absolute;
     z-index: 2;
   }
@@ -1311,37 +1307,36 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .leo_line_container {
-    top: 454px;
-    left: -167px;
+    top: 587px;
+    left: -111px;
     height: 8%;
   }
 
   .leo_label {
-    left: 100px;
-    top: 72px;
-    height: 8%;
+    left: 170px;
+    top: 130px;
   }
 
   .meo_line_container {
-    top: 463px;
-    left: -197px;
+    top: 575px;
+    left: -168px;
     height: 8%;
   }
 
   .meo_label {
-    left: 79px;
-    top: 47px;
+    left: 166px;
+    top: 72px;
   }
 
   .heo_line_container {
-    top: 257px;
-    left: 151px;
+    top: 247px;
+    left: 427px;
     height: 63%;
   }
 
   .heo_label {
-    left: 316px;
-    top: 67px;
+    left: 531px;
+    top: 107px;
   }
 
   .heo_solid {
@@ -1350,25 +1345,24 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .gso_line_container {
-    top: 521px;
-    left: 91px;
-    height: 8%;
+    top: 550px;
+    left: -209px;
   }
 
   .gso_label {
-    left: 73px;
-    top: 14px;
+    left: 120px;
+    top: 29px;
   }
 
   .geo_line_container {
-    top: 438px;
-    left: 83px;
+    top: 569px;
+    left: 232px;
     height: 2%;
   }
 
   .geo_label {
-    left: 45px;
-    top: 190px;
+    left: 58px;
+    top: 312px;
   }
 
   .geo_fill {
@@ -1376,14 +1370,14 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .gto_line_container {
-    top: 436px;
-    left: 67px;
+    top: 562px;
+    left: 237px;
     height: 1%;
   }
 
   .gto_label {
-    left: 125px;
-    top: 184px;
+    left: 200px;
+    top: 305px;
   }
 
   .gto_solid_active {
@@ -1520,6 +1514,29 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     top: -35%;
     user-select: none;
     z-index: 0 !important;
+  }
+}
+
+
+@media (max-width: 750px) {
+  .splash_screen_body {
+    width: 90%;
+  }
+
+  .orbit_closeup_text {
+    margin-left: 12%;
+  }
+
+  .orbit_closeup_button_outlined {
+    font-size: 30px;
+  }
+
+  .orbit_closeup_button_plain {
+    font-size: 30px;
+  }
+
+  .earth_orbits_container {
+    left: 18vw;
   }
 }
 
@@ -1728,6 +1745,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 }
 
 @media (max-height: 640px) {
+
   /* Shrink popup container for shorter height devices */
   .orbit_title_popup_container {
     height: 45%;

--- a/src/App.css
+++ b/src/App.css
@@ -907,6 +907,11 @@ body,
   }
 }
 
+
+.orbit_closeup_text {
+  height: 80vh;
+}
+
 /* iPad Air - Landscape */
 /* Acceptable */
 @media (max-width: 1180px) {
@@ -958,6 +963,7 @@ body,
   }
 }
 
+
 /* iPad Mini - Landscape */
 /* Samsung Galaxy Tab S8 - Landscape */
 @media (max-width: 1040px) {
@@ -971,9 +977,7 @@ body,
     top: 398px;
   }
 
-  .orbit_closeup_text {
-    height: 80vh;
-  }
+
 
   .orbit_closeup_button_plain,
   .orbit_closeup_button_outlined {

--- a/src/App.css
+++ b/src/App.css
@@ -1023,7 +1023,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 
   .gso_label {
     left: 29%;
-    top:9%;
+    top: 9%;
   }
 
   .geo_line_container {
@@ -1309,11 +1309,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     font-size: 16px;
   }
 
-  .earth_orbits_contaienr {
-    min-height: unset;
-    min-width: unset;
-  }
-
   .popup_line_container,
   .earth_orbits_container {
     position: fixed;
@@ -1361,24 +1356,21 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     padding-top: 10px;
     width: var(--mobile-view-width);
     left: 0%;
-    height: 35%;
-    min-height: 340px;
+    height: 40%;
     top: 0;
-    display: flex;
-    flex-direction: column;
-    align-self: start;
-    justify-content: flex-start;
   }
 
   .orbit_popup_button {
     border-style: none;
+    font-size: 20px;
     padding: 10px 25px;
-    top: 33%;
+    top: 40%;
     left: 10%;
     /* Fixes button sizing on iPhone 11 Safari */
     width: auto;
     height: fit-content;
   }
+
 
   .orbit_title_info_header {
     overflow: unset;
@@ -1389,20 +1381,23 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .orbit_title_info_footer {
-    display: hidden;
+    flex: 0.07;
   }
 
   .orbit_title_info_body {
     /* outline: 2px dotted yellow; */
     font-size: 16px;
     width: 85%;
-    height: 25%;
-    flex: auto;
+    flex: 1;
+  }
+
+  .orbit_popup_button {
+    font-size: 30px;
+    top: 39%;
   }
 
   .risk_icon {
     margin-right: 12px;
-    height: 40px;
   }
 
   .drawing {
@@ -1665,8 +1660,9 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 }
 
 
-/* Phones (Portrait) */
-@media (max-width: 500px) {
+/* Phones (Portrait)*/
+/* Desktop */
+@media (max-width: 740px) {
   :root {
     --mobile-orbit-size: 360px;
     --mobile-view-width: 90vw;
@@ -1749,7 +1745,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     width: 90%;
     font-size: 32px;
     flex: unset;
-    padding-bottom: 8px;
+    padding-bottom: 0;
   }
 
   .orbit_title_info_footer {
@@ -2055,14 +2051,5 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   .gto_label {
     left: 100px;
     top: 140px;
-  }
-}
-
-@media (max-height: 640px) {
-
-  /* Shrink popup container for shorter height devices */
-  .orbit_title_popup_container {
-    height: 45%;
-    top: 51%;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1630,13 +1630,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     height: calc(46% - var(--mobile-orbit-top-offset));
   }
 
-  .popup_line_container,
-  .earth_orbits_container {
-    top: var(--mobile-orbit-top-offset);
-    left: 50%;
-  }
-
-
 
   .orbit_title_info_header {
     overflow: unset;

--- a/src/App.css
+++ b/src/App.css
@@ -932,16 +932,30 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     transform: scale(1) !important;
   }
 
-  .orbit_title_container {
-    z-index: -1;
-  }
-
   .orbit_nav_button {
     height: 6vh;
   }
 
+  .orbit_title_container {
+    z-index: -1;
+  }
+
+  .orbit_title_info_header {
+    width: 80%;
+  }
+
+  .orbit_title_info_body {
+    flex: 2;
+  }
+
+  .orbit_title_popup {
+    height: 90%;
+    top: 5%;
+  }
+
   .orbit_popup_button {
     padding: 5px 30px;
+    top: 85%;
   }
 
   .earth {
@@ -952,8 +966,10 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     height: 30vh;
   }
 
-  .gso_line_container {
-    z-index: -1;
+
+  .gso_label {
+    left: 29%;
+    top: 10%;
   }
 
   .leo_line_container {
@@ -962,10 +978,23 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     z-index: -1;
   }
 
+  .leo_label {
+    top: 20%;
+    left: 38%;
+  }
+
+  .meo_label {
+    top: 12%;
+    left: 35%;
+  }
+
+  .meo_line_container {
+    left: 47%;
+  }
 
   .heo_line_container {
-    height: 30.5vh;
-    z-index: -1;
+    height: 35.5vh;
+    left: 50%;
   }
 
   .gso_line_container {
@@ -973,27 +1002,22 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     z-index: -1;
   }
 
-  /* Styles */
   .geo_line_container {
     height: 8vh;
   }
 
-  .orbit_title_popup {
-    height: 90%;
-    top: 5%;
+  .geo_label {
+    left: 290px;
+    top: 250px;
   }
 
   .gto_line_container {
-    left: 49%;
+    left: 56%;
   }
 
-  .orbit_title_info_body {
-    flex: 2;
-  }
 
-  .orbit_popup_button {
-    top: 85%;
-  }
+
+
 
   .static_satellite_image_container {
     width: 64vw;
@@ -1050,7 +1074,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 
 /* iPad Mini - Landscape */
 /* Samsung Galaxy Tab S8 - Landscape */
-@media (max-width: 1040px) {
+/* @media (max-width: 1040px) {
 
   .geo_label {
     left: 131px;
@@ -1064,9 +1088,10 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     height: fit-content;
   }
 
-}
+} */
 
 /* iPad Air - Portrait */
+/* Samsung Galaxy Tab S8 - Portrait */
 /* Desktop  */
 @media (max-width: 1180px) {
   :root {
@@ -1607,25 +1632,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 }
 
-
-/* @media (max-width: 750px) {
-  .splash_screen_body {
-    width: 90%;
-  }
-
-  .orbit_closeup_text {
-    margin-left: 12%;
-  }
-
-  .orbit_closeup_button_outlined {
-    font-size: 30px;
-  }
-
-  .orbit_closeup_button_plain {
-    font-size: 30px;
-  }
-
-} */
 
 /* Phones (Portrait) */
 @media (max-width: 500px) {

--- a/src/App.css
+++ b/src/App.css
@@ -971,7 +971,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 
   .gso_label {
     left: 29%;
-    top: 10%;
+    top: 15%;
   }
 
   .leo_line_container {
@@ -1062,6 +1062,31 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     left: 43%;
   }
 
+  .leo_label {
+    top: 20%;
+    left: 35%;
+  }
+
+  .meo_label {
+    top: 12%;
+    left: 32%;
+  }
+
+  .heo_label {
+    top: 16%;
+    left: 73%;
+  }
+
+  .gso_label {
+    left: 28%;
+    top: 5%;
+  }
+
+  .geo_label {
+    left: 25%;
+    top: 43%;
+  }
+
   .leo_orbit_details,
   .meo_orbit_details,
   .heo_orbit_details,
@@ -1069,7 +1094,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   .geo_orbit_details {
     width: 100%
   }
-} 
+}
 
 /* iPad Air - Portrait */
 /* iPad Mini - Portrait */
@@ -1411,8 +1436,8 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .leo_label {
-    left: 170px;
-    top: 130px;
+    left: 173px;
+    top: 120px;
   }
 
   .meo_line_container {
@@ -1422,7 +1447,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .meo_label {
-    left: 166px;
+    left: 150px;
     top: 72px;
   }
 

--- a/src/App.css
+++ b/src/App.css
@@ -651,7 +651,7 @@ body,
   position: relative;
   text-align: left;
   top: 0%;
-  height: 87%;
+  height: 80%;
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -908,12 +908,8 @@ body,
 }
 
 
-.orbit_closeup_text {
-  height: 80vh;
-}
 
 /* iPad Air - Landscape */
-/* Acceptable */
 @media (max-width: 1180px) {
   :root {
     --min-orbit-size: 900px;

--- a/src/App.css
+++ b/src/App.css
@@ -985,10 +985,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
 
-  .gso_label {
-    left: 29%;
-    top: 15%;
-  }
 
   .leo_line_container {
     height: 11.5vh;
@@ -1015,9 +1011,19 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     left: 50%;
   }
 
+  .heo_label {
+    top: 16%;
+    left: 68%;
+  }
+
   .gso_line_container {
     height: 11.5vh;
     z-index: -1;
+  }
+
+  .gso_label {
+    left: 29%;
+    top:9%;
   }
 
   .geo_line_container {
@@ -1030,7 +1036,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .gto_line_container {
-    left: 50%;
+    left: 55%;
   }
 
 
@@ -1600,6 +1606,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     padding-left: 3%;
     padding-right: 5%;
     padding-bottom: 2%;
+    margin-bottom: 8px;
   }
 
   .orbit_closeup_body {
@@ -1628,6 +1635,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     position: unset;
     width: 75%;
     height: auto;
+    scale: .70;
   }
 
   .orbit_background {

--- a/src/App.css
+++ b/src/App.css
@@ -907,65 +907,135 @@ body,
   }
 }
 
-
-
-/* iPad Air - Landscape */
-@media (max-width: 1180px) {
-  :root {
-    --min-orbit-size: 900px;
-  }
+/* Samsung Galaxy Tab S8 - Landscape */
+@media only screen and (max-device-width : 1235px) and (orientation : landscape) {
 
   .hard_scale_value {
-    transform: scale(0.8) !important;
+    transform: scale(1) !important;
   }
 
-  .static_satellite_closeup {
-    top: -95%;
-    left: -28px;
+  .orbit_title_container {
+    z-index: -1;
+  }
+
+  .orbit_nav_button {
+    height: 6vh;
+  }
+
+  .orbit_popup_button {
+    padding: 5px 30px;
   }
 
   .earth {
-    height: 51%;
+    height: 53%;
   }
 
-  .earth_orbits_container {
-    position: relative;
-    left: 30vw;
-    bottom: 7vh;
-    min-height: var(--min-orbit-size);
-    max-height: var(--min-orbit-size);
-    min-width: var(--min-orbit-size);
-    max-width: var(--min-orbit-size);
+  .drawing {
+    height: 30vh;
   }
 
-  .gso_fill {
-    height: 95%;
+  .gso_line_container {
+    z-index: -1;
   }
 
-  .geo_fill {
-    height: inherit;
+  .leo_line_container {
+    height: 11.5vh;
+    left: 48%;
+    z-index: -1;
   }
 
-  .heo_fill {
-    height: 64.8%;
+
+  .heo_line_container {
+    height: 30.5vh;
+    z-index: -1;
   }
 
-  .meo_fill {
-    height: 78%;
+  .gso_line_container {
+    height: 11.5vh;
+    z-index: -1;
   }
 
-  .leo_fill {
-    height: 61%;
+  /* Styles */
+  .geo_line_container {
+    height: 8vh;
   }
+
+  .orbit_title_popup {
+    height: 90%;
+    top: 5%;
+  }
+
+  .gto_line_container {
+    left: 49%;
+  }
+
+  .orbit_title_info_body {
+    flex: 2;
+  }
+
+  .orbit_popup_button {
+    top: 85%;
+  }
+
+  .static_satellite_image_container {
+    width: 64vw;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .static_satellite_closeup {
+    position: static;
+    scale: 0.5;
+  }
+
 }
 
+
+/* IPad Air 5 Landscape */
+/* IPad Mini Landscape */
+@media only screen and (max-device-width : 1110px) and (orientation : landscape) {
+
+  .orbit_nav_button {
+    height: 6.5vh;
+  }
+
+  .orbit_title_popup {
+    height: 85%;
+    top: 10%;
+  }
+
+  .gto_line_container {
+    left: 46%;
+  }
+
+  .leo_line_container {
+    left: 43%;
+  }
+
+  .orbit_closeup_button_plain,
+  .orbit_closeup_button_outlined {
+    font-size: 24px;
+    padding: 12px 32px;
+    height: fit-content;
+  }
+
+  .leo_orbit_details,
+  .meo_orbit_details,
+  .heo_orbit_details,
+  .gso_orbit_details,
+  .geo_orbit_details {
+    width: 100%
+  }
+}
 
 /* iPad Mini - Landscape */
 /* Samsung Galaxy Tab S8 - Landscape */
 @media (max-width: 1040px) {
-  .earth_orbits_container {
+  /* .earth_orbits_container {
     top: -10vh;
-  }
+  } */
 
 
   .geo_label {
@@ -1240,15 +1310,19 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     padding-top: 10px;
     width: var(--mobile-view-width);
     left: 0%;
-    height: 40%;
+    height: 35%;
+    min-height: 340px;
     top: 0;
+    display: flex;
+    flex-direction: column;
+    align-self: start;
+    justify-content: flex-start;
   }
 
   .orbit_popup_button {
     border-style: none;
-    font-size: 20px;
     padding: 10px 25px;
-    top: 40%;
+    top: 33%;
     left: 10%;
     /* Fixes button sizing on iPhone 11 Safari */
     width: auto;
@@ -1260,16 +1334,19 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     height: fit-content;
     width: 90%;
     font-size: 40px;
+    flex: unset;
   }
 
   .orbit_title_info_footer {
-    flex: 0.07;
+    display: hidden;
   }
 
   .orbit_title_info_body {
+    /* outline: 2px dotted yellow; */
     font-size: 16px;
     width: 85%;
-    flex: 1;
+    height: 25%;
+    flex: auto;
   }
 
   .risk_icon {
@@ -1951,6 +2028,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   /* Shrink popup container for shorter height devices */
   .orbit_title_popup_container {
     height: 45%;
-    top: 55%;
+    top: 51%;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1388,7 +1388,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     /* outline: 2px dotted yellow; */
     font-size: 16px;
     width: 85%;
-    flex: 1;
+    flex: 0.8;
   }
 
   .orbit_popup_button {
@@ -1755,7 +1755,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   .orbit_title_info_body {
     font-size: 12px;
     width: 85%;
-    flex: 1;
   }
 
   .orbit_title_info_section {

--- a/src/App.css
+++ b/src/App.css
@@ -1002,11 +1002,11 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   visibility: hidden;
 }
 
-.title_info_section {
+.orbit_title_info_section {
   font-weight: bold;
 }
 
-.title_info_section span {
+.orbit_title_info_section span {
   font-weight: normal;
 }
 
@@ -1279,7 +1279,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     flex: 1;
   }
 
-  .title_info_section {
+  .orbit_title_info_section {
     margin-bottom: 16px;
   }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1556,9 +1556,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     font-size: 30px;
   }
 
-  .earth_orbits_container {
-    left: 18vw;
-  }
 }
 
 @media (max-width: 500px) {

--- a/src/App.css
+++ b/src/App.css
@@ -1039,7 +1039,6 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   .nav_container {
     /* outline: 2px dotted yellow; */
     width: var(--mobile-view-width);
-    animation-name: unset;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/App.css
+++ b/src/App.css
@@ -98,7 +98,7 @@ body,
 .earth {
   position: absolute;
   z-index: -1;
-  height: 50%;
+  height: 54%;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -907,6 +907,24 @@ body,
   }
 }
 
+
+
+/*****************************************************************************************************************************************************/
+
+/* 
+Note: Because this site is being viewed through an iFrame that has a set height of 900px, adjustments were made to the styling of mobile devices to 
+accomodate that. This comes in the form a large amount of empty space on the bottom of the screen. 
+Also, some elements appear to overlap, or be awkwardly placed when viewing alone but not when viewed within the staging site.
+*/
+
+.hidden {
+  display: none !important;
+}
+
+.orbit_closeup_back_button_mobile {
+  visibility: hidden;
+}
+
 /* Samsung Galaxy Tab S8 - Landscape */
 @media only screen and (max-device-width : 1235px) and (orientation : landscape) {
 
@@ -1033,17 +1051,11 @@ body,
 /* iPad Mini - Landscape */
 /* Samsung Galaxy Tab S8 - Landscape */
 @media (max-width: 1040px) {
-  /* .earth_orbits_container {
-    top: -10vh;
-  } */
-
 
   .geo_label {
     left: 131px;
     top: 398px;
   }
-
-
 
   .orbit_closeup_button_plain,
   .orbit_closeup_button_outlined {
@@ -1054,25 +1066,9 @@ body,
 
 }
 
-
-/*****************************************************************************************************************************************************/
-
-/* 
-Note: Because this site is being viewed through an iFrame that has a set height of 900px, adjustments were made to the styling of mobile devices to 
-accomodate that. This comes in the form a large amount of empty space on the bottom of the screen. 
-Also, some elements appear to overlap, or be awkwardly placed when viewing alone but not when viewed within the staging site.
-*/
-
-.hidden {
-  display: none !important;
-}
-
-.orbit_closeup_back_button_mobile {
-  visibility: hidden;
-}
-
 /* iPad Air - Portrait */
-@media (max-width: 1000px) {
+/* Desktop  */
+@media (max-width: 1180px) {
   :root {
     --mobile-orbit-size: 600px;
     --mobile-view-width: 90vw;

--- a/src/App.css
+++ b/src/App.css
@@ -28,8 +28,7 @@ body,
   position: absolute;
   width: 100%;
   height: 100%;
-  background: linear-gradient(113deg, #0024394d 0%, #3631354d 100%) 0% 0%
-    no-repeat padding-box;
+  background: linear-gradient(113deg, #0024394d 0%, #3631354d 100%) 0% 0% no-repeat padding-box;
   opacity: 1;
   z-index: 1;
 }
@@ -1003,6 +1002,14 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   visibility: hidden;
 }
 
+.title_info_section {
+  font-weight: bold;
+}
+
+.title_info_section span {
+  font-weight: normal;
+}
+
 @media (max-width: 500px) {
   :root {
     --mobile-orbit-size: 360px;
@@ -1206,6 +1213,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     z-index: -1;
   }
 
+
   .earth {
     transform: translate(-50%, -50%);
     z-index: -1;
@@ -1257,6 +1265,8 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     height: fit-content;
     width: 90%;
     font-size: 32px;
+    flex: unset;
+    padding-bottom: 8px;
   }
 
   .orbit_title_info_footer {
@@ -1267,6 +1277,10 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     font-size: 12px;
     width: 85%;
     flex: 1;
+  }
+
+  .title_info_section {
+    margin-bottom: 16px;
   }
 
   .risk_icon {
@@ -1741,6 +1755,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 }
 
 @media (max-height: 640px) {
+
   /* Shrink popup container for shorter height devices */
   .orbit_title_popup_container {
     height: 45%;

--- a/src/App.css
+++ b/src/App.css
@@ -965,6 +965,12 @@ body,
     top: -10vh;
   }
 
+
+  .geo_label {
+    left: 131px;
+    top: 398px;
+  }
+
   .orbit_closeup_text {
     height: 80vh;
   }

--- a/src/App.css
+++ b/src/App.css
@@ -1540,6 +1540,201 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 }
 
+@media (max-width: 500px) {
+  :root {
+    --mobile-orbit-size: 360px;
+    --mobile-view-width: 90vw;
+    --mobile-view-splash-body-width: 60vw;
+    --mobile-orbit-top-offset: 90px;
+  }
+
+  .orbit_closeup_back_button_mobile {
+    visibility: visible;
+    position: relative;
+    top: -35.5vh;
+    left: 86vw;
+  }
+
+  .hard_scale_value {
+    transform: scale(1) !important;
+  }
+
+  .nav_container {
+    height: 70px;
+    margin-top: 20px;
+  }
+
+
+  .orbit_name {
+    position: relative;
+    width: 0;
+  }
+
+  .orbit_name.meo {
+    top: 0px;
+    left: 8px;
+  }
+
+  .orbit_name.leo {
+    top: 0px;
+    left: 8px;
+  }
+
+  .orbit_name.gso {
+    top: 0px;
+    left: -89px;
+  }
+
+  .orbit_name.heo {
+    top: 8px;
+    left: 71px;
+  }
+
+  .orbit_name.geo {
+    user-select: none;
+    top: 8px;
+    left: -17px;
+  }
+
+  .orbit_name.gto {
+    top: 8px;
+    left: -51px;
+  }
+
+  .orbit_nav_button_image {
+    height: 40px;
+  }
+
+  .reset_selection {
+    opacity: 30%;
+    align-self: flex-end;
+    z-index: 2;
+  }
+
+  .reset_selection.top {
+    top: var(--mobile-orbit-top-offset);
+    height: calc(46% - var(--mobile-orbit-top-offset));
+  }
+
+  .popup_line_container,
+  .earth_orbits_container {
+    top: var(--mobile-orbit-top-offset);
+    left: 50%;
+  }
+
+
+
+  .orbit_title_info_header {
+    overflow: unset;
+    height: fit-content;
+    width: 90%;
+    font-size: 32px;
+    flex: unset;
+    padding-bottom: 8px;
+  }
+
+  .orbit_title_info_footer {
+    flex: 0.07;
+  }
+
+  .orbit_title_info_body {
+    font-size: 12px;
+    width: 85%;
+    flex: 1;
+  }
+
+  .orbit_title_info_section {
+    margin-bottom: 16px;
+  }
+
+  .risk_icon {
+    height: unset;
+    margin-right: 12px;
+  }
+
+  ._label img {
+    height: 25px;
+  }
+
+  .leo_line_container {
+    top: 454px;
+    left: -167px;
+    height: 8%;
+  }
+
+  .leo_label {
+    left: 100px;
+    top: 72px;
+    height: 8%;
+  }
+
+  .meo_line_container {
+    top: 463px;
+    left: -197px;
+    height: 8%;
+  }
+
+  .meo_label {
+    left: 79px;
+    top: 47px;
+  }
+
+  .heo_line_container {
+    top: 257px;
+    left: 151px;
+    height: 63%;
+  }
+
+  .heo_label {
+    left: 316px;
+    top: 67px;
+  }
+
+  .heo_solid {
+    top: 36%;
+    left: 59%;
+  }
+
+  .gso_line_container {
+    top: 521px;
+    left: 91px;
+    height: 8%;
+  }
+
+  .gso_label {
+    left: 73px;
+    top: 14px;
+  }
+
+  .geo_line_container {
+    top: 438px;
+    left: 83px;
+    height: 2%;
+  }
+
+  .geo_label {
+    left: 45px;
+    top: 190px;
+  }
+
+  .geo_fill {
+    top: 51%;
+  }
+
+  .gto_line_container {
+    top: 436px;
+    left: 67px;
+    height: 1%;
+  }
+
+  .gto_label {
+    left: 125px;
+    top: 184px;
+  }
+
+}
+
+
 @media (max-width: 400px) {
   :root {
     --mobile-orbit-size: 330px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,7 @@ export const App: React.FC = () => {
 
         // Remove any transform origin that may have been set for a fly transition, will cause the element to be off center
         earth_orbits_container.style.transformOrigin = "";
-      } else if (windowWidth < 1920 && windowWidth > 500) {
+      } else if (windowWidth < 1920 && windowWidth > 1000) {
         const loss = 1920 - windowWidth;
         const percentLoss = Math.round(loss / 19.2);
         const scaleNum = 1 - percentLoss / 100;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,8 +39,6 @@ export const App: React.FC = () => {
   const earthOrbitsScale = useSelector(
     (state: RootState) => state.app.earthOrbitsScale
   );
-  const isMobileDevice = useIsMobileDevice();
-  const showNavBar = isMobileDevice || (!isSplashScreen && !isMobileDevice);
 
   const handleResize = () => {
     adjustElementScale(document.documentElement.clientWidth);
@@ -142,26 +140,30 @@ export const App: React.FC = () => {
               className="reset_selection bottom"
               onClick={resetOrbitSelection}
             ></div>
-          </>
-        )}
-        {showNavBar && (
-          <div className="nav_container">
-            {!flyToId && (
-              <div className="orbit_title_container">
-                {orbitIds.map((id) => {
-                  return <OrbitTitleGroup key={id + "_orbit_title_group_component"} id={id} tabIndex={0} />;
-                })}
-
-                <div className="popup_line_container">
+            <div className="nav_container">
+              {!flyToId && (
+                <div className="orbit_title_container">
                   {orbitIds.map((id) => {
-                    return <PopUpLine key={id + "_popupline"} id={id} />;
+                    return (
+                      <OrbitTitleGroup
+                        key={id + "_orbit_title_group_component"}
+                        id={id}
+                        tabIndex={0}
+                      />
+                    );
                   })}
-                </div>
-              </div>
-            )}
 
-            {!flyToId && activeId && <PopUpText />}
-          </div>
+                  <div className="popup_line_container">
+                    {orbitIds.map((id) => {
+                      return <PopUpLine key={id + "_popupline"} id={id} />;
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {!flyToId && activeId && <PopUpText />}
+            </div>
+          </>
         )}
 
         <EarthOrbitsContainer />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ export const App: React.FC = () => {
     (state: RootState) => state.app.earthOrbitsScale
   );
 
+  const isMobileDevice = useIsMobileDevice();
   const handleResize = () => {
     adjustElementScale(document.documentElement.clientWidth);
     dispatch(setActiveId(""));
@@ -74,10 +75,9 @@ export const App: React.FC = () => {
           earth_orbits_container.style.transform =
             "scale(" + { earthOrbitsScale } + ")";
         }
-
         // Remove any transform origin that may have been set for a fly transition, will cause the element to be off center
         earth_orbits_container.style.transformOrigin = "";
-      } else if (windowWidth < 1920 && windowWidth > 1000) {
+      } else if (windowWidth < 1920 && !isMobileDevice) {
         const loss = 1920 - windowWidth;
         const percentLoss = Math.round(loss / 19.2);
         const scaleNum = 1 - percentLoss / 100;

--- a/src/components/PopUpText.tsx
+++ b/src/components/PopUpText.tsx
@@ -47,13 +47,13 @@ const PopUpText: React.FC = () => {
       <div className="orbit_title_popup">
         <div className="orbit_title_info_header">{headerText}</div>
         <div className="orbit_title_info_body" tabIndex={0}>
-          <section className="title_info_section">
+          <section className="orbit_title_info_section">
             Distance: <span>{bodyDistanceText}</span>
           </section>
-          <section className="title_info_section">
+          <section className="orbit_title_info_section">
             About: <span>{bodyAboutText}</span>
           </section>
-          <section className="title_info_section">
+          <section className="orbit_title_info_section">
             Risks
             <span>
               <RiskIcons

--- a/src/components/PopUpText.tsx
+++ b/src/components/PopUpText.tsx
@@ -47,20 +47,27 @@ const PopUpText: React.FC = () => {
       <div className="orbit_title_popup">
         <div className="orbit_title_info_header">{headerText}</div>
         <div className="orbit_title_info_body" tabIndex={0}>
-          <strong>Distance: </strong>
-          {bodyDistanceText}
-          <br />
-          <strong>About: </strong>
-          {bodyAboutText}
-          <br />
-          <strong>Risks</strong>
-          <RiskIcons key={activeId + "_risk_icon_component"} id={activeId} />
+          <section className="orbit_title_info_section">
+            Distance: <span>{bodyDistanceText}</span>
+          </section>
+          <section className="orbit_title_info_section">
+            About: <span>{bodyAboutText}</span>
+          </section>
+          <section className="orbit_title_info_section">
+            Risks
+            <span>
+              <RiskIcons
+                key={activeId + "_risk_icon_component"}
+                id={activeId}
+              />
+            </span>
+          </section>
         </div>
         <div className="orbit_title_info_footer"></div>
       </div>
       {activeId !== "gto" && (
         <button
-        key={activeId + "orbit_popup_button"}
+          key={activeId + "orbit_popup_button"}
           id={activeId}
           className="orbit_popup_button"
           onClick={flyToOrbit}

--- a/src/components/PopUpText.tsx
+++ b/src/components/PopUpText.tsx
@@ -47,20 +47,27 @@ const PopUpText: React.FC = () => {
       <div className="orbit_title_popup">
         <div className="orbit_title_info_header">{headerText}</div>
         <div className="orbit_title_info_body" tabIndex={0}>
-          <strong>Distance: </strong>
-          {bodyDistanceText}
-          <br />
-          <strong>About: </strong>
-          {bodyAboutText}
-          <br />
-          <strong>Risks</strong>
-          <RiskIcons key={activeId + "_risk_icon_component"} id={activeId} />
+          <section className="title_info_section">
+            Distance: <span>{bodyDistanceText}</span>
+          </section>
+          <section className="title_info_section">
+            About: <span>{bodyAboutText}</span>
+          </section>
+          <section className="title_info_section">
+            Risks
+            <span>
+              <RiskIcons
+                key={activeId + "_risk_icon_component"}
+                id={activeId}
+              />
+            </span>
+          </section>
         </div>
         <div className="orbit_title_info_footer"></div>
       </div>
       {activeId !== "gto" && (
         <button
-        key={activeId + "orbit_popup_button"}
+          key={activeId + "orbit_popup_button"}
           id={activeId}
           className="orbit_popup_button"
           onClick={flyToOrbit}

--- a/src/hooks/isMobileDevice.tsx
+++ b/src/hooks/isMobileDevice.tsx
@@ -10,5 +10,5 @@ export default function useIsMobileDevice() {
     };
     window.addEventListener("resize", updateDimension);
   }, [screenWidth]);
-  return screenWidth <= 1180;
+  return screenWidth <= 1132;
 }

--- a/src/hooks/isMobileDevice.tsx
+++ b/src/hooks/isMobileDevice.tsx
@@ -1,14 +1,3 @@
-import React from "react";
-
 export default function useIsMobileDevice() {
-  const [screenWidth, setscreenWidth] = React.useState<number>(
-    window.innerWidth
-  );
-  React.useEffect(() => {
-    const updateDimension = () => {
-      setscreenWidth(window.innerWidth);
-    };
-    window.addEventListener("resize", updateDimension);
-  }, [screenWidth]);
-  return screenWidth <= 1132;
+  return window.innerWidth <= 1132;
 }

--- a/src/hooks/isMobileDevice.tsx
+++ b/src/hooks/isMobileDevice.tsx
@@ -10,5 +10,5 @@ export default function useIsMobileDevice() {
     };
     window.addEventListener("resize", updateDimension);
   }, [screenWidth]);
-  return screenWidth <= 500;
+  return screenWidth <= 1000;
 }

--- a/src/hooks/isMobileDevice.tsx
+++ b/src/hooks/isMobileDevice.tsx
@@ -10,5 +10,5 @@ export default function useIsMobileDevice() {
     };
     window.addEventListener("resize", updateDimension);
   }, [screenWidth]);
-  return screenWidth <= 1000;
+  return screenWidth <= 1180;
 }


### PR DESCRIPTION
I apparently made isMobileDevice much more complicated than it had to be. With this change it should no longer crash when rotating the tablet due to a conflict of event listeners on the window.