### PR TITLE
BugFix/NONE/fix-useMobileDevice

### DIFF
--- a/src/hooks/isMobileDevice.tsx
+++ b/src/hooks/isMobileDevice.tsx
@@ -1,14 +1,3 @@
-import React from "react";
-
 export default function useIsMobileDevice() {
-  const [screenWidth, setscreenWidth] = React.useState<number>(
-    window.innerWidth
-  );
-  React.useEffect(() => {
-    const updateDimension = () => {
-      setscreenWidth(window.innerWidth);
-    };
-    window.addEventListener("resize", updateDimension);
-  }, [screenWidth]);
-  return screenWidth <= 1132;
+  return window.innerWidth <= 1132;
 }


### PR DESCRIPTION
I apparently made isMobileDevice much more complicated than it had to be. With this change it should no longer crash when rotating the tablet due to a conflict of event listeners on the window.