### PR TITLE
Improvement/NONE/tablet UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1084,9 +1084,11 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   .leo_line_container {
     left: 28%;
   }
+
   .meo_line_container {
     left: 40%;
   }
+
   .gto_line_container {
     left: 32%;
   }
@@ -1562,6 +1564,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 
   .orbit_closeup_container {
     position: relative;
+    padding-top: 20px;
     width: 90%;
     height: 51%;
     top: 27%;
@@ -1588,9 +1591,10 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     /* outline: 2px dotted tomato; */
     max-width: 100vw;
     padding: 0 40px;
-    height: 66%;
+    height: 78%;
     margin-left: 0%;
     margin-top: 3%;
+    line-height: 1.2;
   }
 
   .orbit_closeup_header {
@@ -1611,13 +1615,17 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
     margin-bottom: 8px;
   }
 
+  .orbit_closeup_body p{
+    margin-top: 0;
+  }
   .orbit_closeup_body {
     font-size: 15px;
     letter-spacing: 0px;
-    line-height: 2;
+    line-height: 1.8;
     padding-left: 3%;
     padding-right: 5%;
     padding-bottom: 5%;
+    padding-top:0;
   }
 
   .static_satellite_image_container {

--- a/src/App.css
+++ b/src/App.css
@@ -10,6 +10,7 @@ body,
   display: flex;
   overflow: hidden;
   --reset_selection_left: 180px;
+  --version: 1;
 }
 
 .background_container {

--- a/src/App.css
+++ b/src/App.css
@@ -10,7 +10,7 @@ body,
   display: flex;
   overflow: hidden;
   --reset_selection_left: 180px;
-  --version: 1;
+  --version: 1.2;
 }
 
 .background_container {
@@ -989,7 +989,7 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
 
   .leo_line_container {
     height: 11.5vh;
-    left: 48%;
+    left: 30%;
     z-index: -1;
   }
 
@@ -1032,12 +1032,12 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .geo_label {
-    left: 290px;
-    top: 250px;
+    left: 22%;
+    top: 43%;
   }
 
   .gto_line_container {
-    left: 55%;
+    left: 35%;
   }
 
 
@@ -1082,7 +1082,13 @@ Also, some elements appear to overlap, or be awkwardly placed when viewing alone
   }
 
   .leo_line_container {
-    left: 43%;
+    left: 28%;
+  }
+  .meo_line_container {
+    left: 40%;
+  }
+  .gto_line_container {
+    left: 32%;
   }
 
   .leo_label {

--- a/src/App.css
+++ b/src/App.css
@@ -10,7 +10,7 @@ body,
   display: flex;
   overflow: hidden;
   --reset_selection_left: 180px;
-  --version: 1.2;
+  --version: 1.3;
 }
 
 .background_container {
@@ -281,8 +281,8 @@ body,
 .geo_label {
   position: absolute;
   z-index: 1;
-  top: 50%;
-  left: 20%;
+  top: 45%;
+  left: 25%;
 }
 
 .gto_label {

--- a/src/components/EarthOrbitsContainer.tsx
+++ b/src/components/EarthOrbitsContainer.tsx
@@ -27,7 +27,11 @@ const EarthOrbitsContainer: React.FC = () => {
       } else {
         //special case for GTO
         orbitElements.push(
-          <SingleOrbitImage key="gto_solid_active" id={activeId} imageDesc="_solid_active" />
+          <SingleOrbitImage
+            key="gto_solid_active"
+            id={activeId}
+            imageDesc="_solid_active"
+          />
         );
       }
 
@@ -74,7 +78,7 @@ const EarthOrbitsContainer: React.FC = () => {
       if (hoveringId) {
         //place all orbit animations at a lighter opacity and not moving, unless it is the one that is hovered.  Note that this only occurs when no orbit is active/selected
         orbitIds.map((id) => {
-          if (hoveringId !== "gto") {
+          if (id !== "gto") {
             orbitElements.push(
               <SingleOrbitAnimation
                 key={id + "_orbit_moving"}
@@ -84,9 +88,23 @@ const EarthOrbitsContainer: React.FC = () => {
               />
             );
           } else {
-            return orbitElements.push(
-              <SingleOrbitImage key="gto_solid_lighter" id={"gto"} imageDesc="_solid_lighter" />
-            );
+            if (hoveringId !== "gto") {
+              orbitElements.push(
+                <SingleOrbitImage
+                  key="gto_solid_lighter"
+                  id={"gto"}
+                  imageDesc="_solid_lighter"
+                />
+              );
+            } else {
+              orbitElements.push(
+                <SingleOrbitImage
+                  key="gto_solid_active"
+                  id={"gto"}
+                  imageDesc="_solid_active"
+                />
+              );
+            }
           }
         });
       } else {
@@ -103,7 +121,11 @@ const EarthOrbitsContainer: React.FC = () => {
             );
           } else {
             orbitElements.push(
-              <SingleOrbitImage key="gto_solid_active" id={"gto"} imageDesc="_solid_active" />
+              <SingleOrbitImage
+                key="gto_solid_active"
+                id={"gto"}
+                imageDesc="_solid_active"
+              />
             );
           }
         });

--- a/src/hooks/isMobileDevice.tsx
+++ b/src/hooks/isMobileDevice.tsx
@@ -1,14 +1,4 @@
-import React from "react";
 
 export default function useIsMobileDevice() {
-  const [screenWidth, setscreenWidth] = React.useState<number>(
-    window.innerWidth
-  );
-  React.useEffect(() => {
-    const updateDimension = () => {
-      setscreenWidth(window.innerWidth);
-    };
-    window.addEventListener("resize", updateDimension);
-  }, [screenWidth]);
-  return screenWidth <= 1132;
+  return window.innerWidth <= 1132;
 }


### PR DESCRIPTION
This includes the show stopper fix
a fix to the geo label AKDS-118
and some slight adjustments to the styling for tablets in portrait.
Ultimately there is no ideal way to view the app on the tablet. The BEST way is to view it in portrait but it is very squishy. But all the buttons needed to navigate are at available without scrolling. Unfortunately, at this point the GTO and GEO orbits are cut off.
If I try to adjust the popup, it will adjust it for all devices.

In landscape on tablet, everything works but the user is forced to scroll around ALOT.

This is already on staging.
![ThisIsIt](https://github.com/rraaschfilament/across-karman/assets/85306386/1b6df6f3-f0b0-456e-a926-980de94772e3)
