### PR TITLE
Bug fix/AKDS-124/gto-orbit-behavior

### DIFF
--- a/src/components/EarthOrbitsContainer.tsx
+++ b/src/components/EarthOrbitsContainer.tsx
@@ -27,7 +27,11 @@ const EarthOrbitsContainer: React.FC = () => {
       } else {
         //special case for GTO
         orbitElements.push(
-          <SingleOrbitImage key="gto_solid_active" id={activeId} imageDesc="_solid_active" />
+          <SingleOrbitImage
+            key="gto_solid_active"
+            id={activeId}
+            imageDesc="_solid_active"
+          />
         );
       }
 
@@ -74,7 +78,7 @@ const EarthOrbitsContainer: React.FC = () => {
       if (hoveringId) {
         //place all orbit animations at a lighter opacity and not moving, unless it is the one that is hovered.  Note that this only occurs when no orbit is active/selected
         orbitIds.map((id) => {
-          if (hoveringId !== "gto") {
+          if (id !== "gto") {
             orbitElements.push(
               <SingleOrbitAnimation
                 key={id + "_orbit_moving"}
@@ -84,9 +88,23 @@ const EarthOrbitsContainer: React.FC = () => {
               />
             );
           } else {
-            return orbitElements.push(
-              <SingleOrbitImage key="gto_solid_lighter" id={"gto"} imageDesc="_solid_lighter" />
-            );
+            if (hoveringId !== "gto") {
+              orbitElements.push(
+                <SingleOrbitImage
+                  key="gto_solid_lighter"
+                  id={"gto"}
+                  imageDesc="_solid_lighter"
+                />
+              );
+            } else {
+              orbitElements.push(
+                <SingleOrbitImage
+                  key="gto_solid_active"
+                  id={"gto"}
+                  imageDesc="_solid_active"
+                />
+              );
+            }
           }
         });
       } else {
@@ -103,7 +121,11 @@ const EarthOrbitsContainer: React.FC = () => {
             );
           } else {
             orbitElements.push(
-              <SingleOrbitImage key="gto_solid_active" id={"gto"} imageDesc="_solid_active" />
+              <SingleOrbitImage
+                key="gto_solid_active"
+                id={"gto"}
+                imageDesc="_solid_active"
+              />
             );
           }
         });


### PR DESCRIPTION
For the hover function,
basically because we are looping over the orbitIds we need to focus on the ids as the driver of the .map function.

The fix was to loop over all of the ids and if the orbitId is not GTO push the SingleOrbitAnimation component( which already handles its own hover behavior)

If the orbitId is gto, the map function it will determine if it is being hovered or not based on the hoverID and display the appropriate orbit accordingly.

This fix also fixes the stuck solid gto orbit.

![opera_VwBDx5zJ9R](https://github.com/rraaschfilament/across-karman/assets/85306386/eefae94b-2bfc-47f7-be81-3755b96a7660)
